### PR TITLE
Pulling from source: update for ST4 and Linux fix

### DIFF
--- a/manual_install.org
+++ b/manual_install.org
@@ -15,14 +15,16 @@
     On Mac you will need to clone like so (NOTE THE CASE!):
 
     #+BEGIN_SRC powershell
-     git clone https://github.com/ihdavids/orgextended.git ~/Library/Application Support/Sublime Text 3/Packages/OrgExtended  
+     git clone https://github.com/ihdavids/orgextended.git ~/Library/Application Support/Sublime Text/Packages/OrgExtended
     #+END_SRC 
 
     On Linux:
 
     #+BEGIN_SRC powershell
-     git clone https://github.com/ihdavids/orgextended.git ~/. config/sublime-text-3/Packages/OrgExtended 
+     git clone https://github.com/ihdavids/orgextended.git ~/.config/sublime-text/Packages/OrgExtended
     #+END_SRC
+
+    Please note that these are all for ST4. If you are running ST3, see Sublime's docs on [[https://www.sublimetext.com/docs/side_by_side.html][different data directories]].
 
     Once cloned you will likely need to restart sublime a couple of times.
     OrgExtended installs some dependencies AND some additional packages.


### PR DESCRIPTION
Updated Pull from source page to work for ST4 and fixed an error in the Linux command.

Things changed:
	- updated to be sublime-text / Sublime Text instead of 3 on Linux & Mac
	- got rid of space on Linux to stop 'fatal: too many arguments' error
	- added link to Sublime's docs for different data directories if running ST3
	
I'm not sure about the link syntax, so let me know if it needs revising!